### PR TITLE
Allow Sketch to specify SPI clock divisor SD.begin

### DIFF
--- a/SD.cpp
+++ b/SD.cpp
@@ -333,7 +333,7 @@ boolean callback_rmdir(SdFile& parentDir, char *filePathComponent,
 
 
 
-boolean SDClass::begin(uint8_t csPin) {
+boolean SDClass::begin(uint8_t csPin, uint8_t spiSpd) {
   /*
 
     Performs the initialisation required by the sdfatlib library.
@@ -341,7 +341,8 @@ boolean SDClass::begin(uint8_t csPin) {
     Return true if initialization succeeds, false otherwise.
 
    */
-  return card.init(SPI_HALF_SPEED, csPin) &&
+   
+	  return card.init(spiSpd, csPin) &&
          volume.init(card) &&
          root.openRoot(volume);
 }

--- a/SD.h
+++ b/SD.h
@@ -69,7 +69,7 @@ private:
 public:
   // This needs to be called to set up the connection to the SD card
   // before other methods are used.
-  boolean begin(uint8_t csPin = SD_CHIP_SELECT_PIN);
+  boolean begin(uint8_t csPin = SD_CHIP_SELECT_PIN, uint8_t spiSpd=SPI_HALF_SPEED);
   
   // Open the specified file/directory with the supplied mode (e.g. read or
   // write, etc). Returns a File object for interacting with the file.


### PR DESCRIPTION
Would this added (optional) parameter conflict with any general SD usage?

SD.begin(10, SPI_QUARTER_SPEED)

When using the SPI overclock in the sketch with AUDIO tutorial hardware and ILI9341 this allows the SD card with SPI OC adjustment to work at 72MHz to 120MHz with no apparent issues (at least reading songs for the Part_3_02 tutorial sample I modified for the ILI9361C thread. On the large ILI9341 it still falls behind - but performance is 12% higher on average doing 83 .vs. 74 FPS on the dual FFT data bars for the first sample song. And the slowest update is 67 FPS .vs. 50.

SPI OC is this: https://forum.pjrc.com/threads/34406-Teensy-3-2-SPI-Clock-over-30-MHz?p=104104&viewfull=1#post104104

At 140MHz the SPI OC results in audio BUZZ and loss of TFT – It seems the TFT can’t handle SPI at that speed as it fails without Audio hardware.

At 48MHz SPI OC works - but the millis() and elapsedMillis runs wrong.

Same millis() issue at 24MHz - however there the SPI OC works to play the Audio at the right speed, without SPI OC the song plays slow.

If I read the (solder on SOIC) RAM clock speed specs this SPI OC will break that over 24MHz?, but it should work on a FLASH that is 80MHz or over?
