### PR TITLE
Add accessors to SDClass

### DIFF
--- a/SD.h
+++ b/SD.h
@@ -88,6 +88,10 @@ public:
   
   boolean rmdir(const char *filepath);
 
+  Sd2Card& getCard() { return card; }
+  SdVolume& getVolume() { return volume; }
+  SdFile& getRoot() { return root; }
+
 private:
 
   // This is used to determine the mode used to open a file


### PR DESCRIPTION
SDClass maintains three data members that may be of interest to callers
but are not exposed. Additionally, they are declared private so could not
be made available by subclassing SDClass. Present commit adds three
one-line accessor functions to allow acces to these members by reference.