### PR TITLE
check alignment for DMA buffers

### DIFF
--- a/utility/NXP_SDHC.cpp
+++ b/utility/NXP_SDHC.cpp
@@ -581,6 +581,10 @@ int SDHC_CardReadBlock(void * buff, uint32_t sector)
 {
   int result=0;
   uint32_t* pData = (uint32_t*)buff;
+  /* check alignment for DMA */
+  if (reinterpret_cast<uintptr_t>(static_cast<const void*>(buff)) % 4) {
+    return -1;
+  }
 //  Serial.print("Sector: "); Serial.println(sector); Serial.flush();
   // Check if this is ready
   if (sdCardDesc.status != 0) return SDHC_RESULT_NOT_READY;
@@ -640,6 +644,10 @@ int SDHC_CardWriteBlock(const void * buff, uint32_t sector)
 {
   int result=0;
   const uint32_t *pData = (const uint32_t *)buff;
+  /* check alignment for DMA */
+  if (reinterpret_cast<uintptr_t>(static_cast<const void*>(buff)) % 4) {
+    return -1;
+  }
 
   // Check if this is ready
   if (sdCardDesc.status != 0) return SDHC_RESULT_NOT_READY;


### PR DESCRIPTION
I really like the idea of using DMA to access the SD card, but you should check the user-supplied buffers to `SDHC_CardReadBlock(()` and `SDHC_CardWriteBlock()` for a correct alignment to prevent data corruption. The least 2 significant bits of `SDHC_DSADDR` are always 0 on a K66 device, therefore the buffer address has to be 4 byte aligned.
