### PR TITLE
Format was using the predefined SD object instead of instance.

### DIFF
--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -43,7 +43,7 @@ void SDClass::dateTime(uint16_t *date, uint16_t *time)
 
 bool SDClass::format(int type, char progressChar, Print& pr)
 {
-	SdCard *card = SD.sdfs.card();
+	SdCard *card = sdfs.card();
 	if (!card) return false; // no SD card
 	uint32_t sectors = card->sectorCount();
 	if (sectors <= 12288) return false; // card too small


### PR DESCRIPTION
@PaulStoffregen @mjs513 -

Mike was having issues where only SD.begin worked in MTP-test sketch... So after fixing to get both disks to show again on the host, and neither excepted a format, figured out you were hard codding to use the SD. object instead of using the object instance you were actaully called on.

Simple fix.  Just remove SD.

Format is now called.  And was able to format the one on Pin 10... But screwed up MTP as it took too long.  So I may need to change my handling of the Format code in MTP and always start up timer and process in background.