### PR TITLE
Card detect pin

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -24,6 +24,7 @@ position	KEYWORD2
 size	KEYWORD2
 format	KEYWORD2
 mediaPresent	KEYWORD2
+setMediaDetectPin	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/src/SD.h
+++ b/src/SD.h
@@ -210,13 +210,22 @@ public:
 	}
 	bool format(int type=0, char progressChar=0, Print& pr=Serial);
 	bool mediaPresent();
+
+	// call to allow you to specify if your SD reader has an IO pin that
+	// can be used to detect if an chip is inserted.  On BUILTIN_SDCARD
+	// we will default to use it if you use the begin method, howver
+	// if you bypass this and call directly to SDFat begin, then you
+	// can use this to let us know. 
+	bool setMediaDetectPin(uint8_t pin);
+
 public: // allow access, so users can mix SD & SdFat APIs
 	SDFAT_BASE sdfs;
 	operator SDFAT_BASE & () { return sdfs; }
 	static void dateTime(uint16_t *date, uint16_t *time);
 private:
 	bool cardPreviouslyPresent = false;
-	uint8_t csPin_ = 0xff;  	
+	uint8_t csPin_ = 0xff;
+	uint8_t cdPin_ = 0xff;
 };
 
 extern SDClass SD;


### PR DESCRIPTION
@PaulStoffregen  @mjs513 

Added a new method to allow sketch to specify an IO pin for external SD cards to use as a media detect pin.  Both Sparkfun and Adafruit boards have them.  Which makes faster detecting of changes. 

As part of the testing with MTP, I found that at times when card went away, that when we tell MTP that storage changed, that when it asked the SD for their new information, it mostly returned previous data as it is cached within the SDFat object. 

I resolved that within the test sketches like:
```
        if (media_present != myfs[i].media_present) {
          storage_changed = true;
          myfs[i].media_present = media_present;
          if (media_present) DBGSerial.printf("\n### %s(%d) inserted dt:%u\n",  myfs[i].name, i, (uint32_t)em);
          else {
            DBGSerial.printf("\n### %s(%d) removed dt:%u\n",  myfs[i].name, i, (uint32_t)em);
            myfs[i].sd.sdfs.end();
          }
        } else {
```
But wondering if I should put the call to sdfs.end(); within the mediaPresent call when we detect the transition? 
