### PR TITLE
Have the getModifyTime/create... check for SDFat returning 0's

### DIFF
--- a/src/SD.h
+++ b/src/SD.h
@@ -135,6 +135,7 @@ public:
 	virtual bool getCreateTime(DateTimeFields &tm) {
 		uint16_t fat_date, fat_time;
 		if (!sdfatfile.getCreateDateTime(&fat_date, &fat_time)) return false;
+		if ((fat_date == 0) && (fat_time == 0)) return false;
 		tm.sec = FS_SECOND(fat_time);
 		tm.min = FS_MINUTE(fat_time);
 		tm.hour = FS_HOUR(fat_time);
@@ -146,6 +147,7 @@ public:
 	virtual bool getModifyTime(DateTimeFields &tm) {
 		uint16_t fat_date, fat_time;
 		if (!sdfatfile.getModifyDateTime(&fat_date, &fat_time)) return false;
+		if ((fat_date == 0) && (fat_time == 0)) return false;
 		tm.sec = FS_SECOND(fat_time);
 		tm.min = FS_MINUTE(fat_time);
 		tm.hour = FS_HOUR(fat_time);


### PR DESCRIPTION
@PaulStoffregen  @mjs513 

If they return 0, we bail and return false.  This implied that no date/time was found, and  or calling code was blindly using the values like month of 255...

This avoids/fixes issue with the SD listfiles faulting if SDFat returned 0s for date and time we translate for example month to 255, which we index and try to print... 

Feels cleaner than hacking it in the sketch code