### PR TITLE
Update format to correct issue with SDIO exFAT

### DIFF
--- a/src/SD.cpp
+++ b/src/SD.cpp
@@ -74,6 +74,7 @@ bool SDClass::format(int type, char progressChar, Print& pr)
 	free(buf);
 	if (ret) {
 		// TODO: Is begin() really necessary?  Is a quicker way possible?
+		card->syncDevice();
 		sdfs.restart(); // TODO: is sdfs.volumeBegin() enough??
 	}
 	return ret;


### PR DESCRIPTION
@PaulStoffregen  - @KurtE 

Added one extra call to card->synchDevice() in formatting function to correct the issue in @KurtE's [post #1276](https://forum.pjrc.com/threads/68139-Teensyduino-File-System-Integration-including-MTP-and-MSC?p=308095&viewfull=1#post308095), i.e.

` Format of SD cards, does not always properly reset the MTP stuff in some cases..... Best Guess Issue: Our code in SD.format() has code in it to try to restart the file system with the new setup. And my guess is that this is not working fully for ExFat on SDIO`

I tested with a 64GB exFAT card and Kurt tested with a 128GB exFAT card - seems to have resolved the issue.

