### PR TITLE
If we detected no SD return 0 for usedSize/totalSize

### DIFF
--- a/examples/SdFat_Usage/SdFat_Usage.ino
+++ b/examples/SdFat_Usage/SdFat_Usage.ino
@@ -119,7 +119,7 @@ void setup()
     Serial.print("  unable to preallocate this file");
   }
   myfile.print("Just some test data written to the file (by SdFat functions)");
-  myfile.write('\0'); // add a null byte to mark end of string
+  myfile.write((uint8_t)'\0'); // add a null byte to mark end of string
   myfile.close();
 
   // You can also use regular SD functions, even to access the same file.  Just

--- a/src/SD.h
+++ b/src/SD.h
@@ -202,10 +202,12 @@ public:
 		return sdfs.rmdir(filepath);
 	}
 	uint64_t usedSize() {
+		if (!cardPreviouslyPresent) return (uint64_t)0;
 		return (uint64_t)(sdfs.clusterCount() - sdfs.freeClusterCount())
 		  * (uint64_t)sdfs.bytesPerCluster();
 	}
 	uint64_t totalSize() {
+		if (!cardPreviouslyPresent) return (uint64_t)0;
 		return (uint64_t)sdfs.clusterCount() * (uint64_t)sdfs.bytesPerCluster();
 	}
 	bool format(int type=0, char progressChar=0, Print& pr=Serial);


### PR DESCRIPTION
Hi @PaulStoffregen @mjs513

With the media detection code when we detect that the SD went away,  when you do a refresh of the top level Teensy object in MTP, it still returns the same values as before as the SDFat has this data cached.

This code simply detect that our cardPreviouslyPresent is set when we do begin and when we do detection so if we belive there is no SD card, simply return 0.

WIth this now if you do a refresh in MTP, the drive shows up in RED as expected.

Edit: Also picked up the change I hit sitting in my branch that SdFat_Usage example sketch was not building.
Not sure why we need to cast: myfile.write((uint8_t)'\0')
But it works